### PR TITLE
Remove dropdown when there are no options present

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce-remove-product-sorting",
-	"version": "1.1.1",
+	"version": "1.2.0-dev",
 	"author": "SkyVerge",
 	"homepage": "http://skyverge.com",
 	"repository": {

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
  - Tested up to: 4.9.4
  - Requires WooCommerce at least: 2.6
  - Tested WooCommerce up to: 3.3.1
- - Stable Tag: 1.1.1
+ - Stable Tag: 1.2.0-dev
  - License: GPLv3
  - License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -59,6 +59,9 @@ Yes you can! Join in on our [GitHub repository](https://github.com/bekarice/wooc
 2. Sorting options on the shop page with some removed
 
 ### Changelog
+
+2018.nn.nn - version 1.2.0-dev
+ * Tweak - Remove the sorting dropdown if all sorting options are removed
 
 2018.02.09 - version 1.1.1
  * Fix - PHP warnings for themes that don't support WooCommerce product column and row settings


### PR DESCRIPTION
A common question is why the dropdown is empty when all options are removed; this PR unhooks the dropdown if there are no detectable sorting options (core or from our Extra Sorting Options plugin).